### PR TITLE
uni025F as jdotless with stroke

### DIFF
--- a/source/Junicode-width.glyphspackage/glyphs/uni025F_.glyph
+++ b/source/Junicode-width.glyphspackage/glyphs/uni025F_.glyph
@@ -7,10 +7,12 @@ layers = (
 layerId = master01;
 shapes = (
 {
-ref = j;
+alignment = -1;
+ref = jdotless;
 },
 {
-pos = (140,-39);
+alignment = -1;
+pos = (140,-239);
 ref = strokeshortcomb;
 scale = (0.8,1);
 }
@@ -21,10 +23,12 @@ width = 253;
 layerId = "75918100-ED89-42A8-B0FE-888EB9C86810";
 shapes = (
 {
-ref = j;
+alignment = -1;
+ref = jdotless;
 },
 {
-pos = (123,-37);
+alignment = -1;
+pos = (123,-234);
 ref = strokeshortcomb;
 scale = (0.8,1);
 }
@@ -35,10 +39,12 @@ width = 243;
 layerId = "6ABD9449-5E80-4451-809E-12ADEB9E9AB4";
 shapes = (
 {
-ref = j;
+alignment = -1;
+ref = jdotless;
 },
 {
-pos = (146,-39);
+alignment = -1;
+pos = (146,-244);
 ref = strokeshortcomb;
 scale = (0.8,1);
 }
@@ -49,10 +55,12 @@ width = 259;
 layerId = "70B83247-6FA0-4662-9656-C86DD2A17D3B";
 shapes = (
 {
-ref = j;
+alignment = -1;
+ref = jdotless;
 },
 {
-pos = (110,-38);
+alignment = -1;
+pos = (110,-238);
 ref = strokeshortcomb;
 scale = (0.8,1);
 }
@@ -63,10 +71,12 @@ width = 217;
 layerId = "9E6FDE2E-55A6-44A9-9556-F1822294BF26";
 shapes = (
 {
-ref = j;
+alignment = -1;
+ref = jdotless;
 },
 {
-pos = (170,-39);
+alignment = -1;
+pos = (170,-239);
 ref = strokeshortcomb;
 scale = (0.8,1);
 }
@@ -77,10 +87,12 @@ width = 292;
 layerId = "00F4936D-6309-4DEC-83B3-42806ED1A477";
 shapes = (
 {
-ref = j;
+alignment = -1;
+ref = jdotless;
 },
 {
-pos = (167,111);
+alignment = -1;
+pos = (167,-239);
 ref = strokeshortcomb;
 scale = (0.8,1);
 }


### PR DESCRIPTION
Update uni025F in Junicode-width.glyphspackage to use jdotless with strokeshortcomb as components instead of j with strokeshortcomb.
Junicode-Italic.glyphspackage already has it dotless but has outlines instead of components, it is left untouched.

Before:
<img width="486" alt="Screenshot 2023-06-27 at 16 26 54" src="https://github.com/psb1558/Junicode-font/assets/1923747/b92ea4af-8f0e-4cd6-b109-e350952937b8">
After:
<img width="499" alt="Screenshot 2023-06-27 at 16 23 34" src="https://github.com/psb1558/Junicode-font/assets/1923747/675c7c91-62a6-417f-926f-89de029ec3b9">
