### PR TITLE
Fix definition of `\textEnlargedMinuscules`

### DIFF
--- a/TeX/junicode.sty
+++ b/TeX/junicode.sty
@@ -367,7 +367,7 @@
 
 \newcommand{\EnlargedMinuscules}{\addfontfeature{StylisticSet=6}} % ss06
 
-\newcommand{\textEnlargedMinuscules}[1]{\addfontfeature{{StylisticSet=6}#1}}
+\newcommand{\textEnlargedMinuscules}[1]{{\addfontfeature{StylisticSet=6}#1}}
 
 \newcommand{\Underdotted}{\addfontfeature{StylisticSet=7}} % ss07
 

--- a/TeX/junicodevf.sty
+++ b/TeX/junicodevf.sty
@@ -225,7 +225,7 @@ mkmainfontcommand(style_idx, weight_option, weight_adjust, width_option, width_a
 \newcommand*{\MediumHighOverline}{\addfontfeature{StylisticSet=5}} % ss05
 \newcommand*{\textMediumHighOverline}[1]{{\addfontfeature{StylisticSet=5}#1}}
 \newcommand*{\EnlargedMinuscules}{\addfontfeature{StylisticSet=6}} % ss06
-\newcommand*{\textEnlargedMinuscules}[1]{\addfontfeature{{StylisticSet=6}#1}}
+\newcommand*{\textEnlargedMinuscules}[1]{{\addfontfeature{StylisticSet=6}#1}}
 \newcommand*{\Underdotted}{\addfontfeature{StylisticSet=7}} % ss07
 \newcommand*{\textUnderdotted}[1]{{\addfontfeature{StylisticSet=7}#1}}
 \newcommand*{\ContextualLongS}{\addfontfeature{StylisticSet=8}} % ss08


### PR DESCRIPTION
Found due to the prior definition resulting in failed compilation when using `Node` or `Base` renderers.